### PR TITLE
Refund returns null on success

### DIFF
--- a/src/Contracts/IPay.php
+++ b/src/Contracts/IPay.php
@@ -229,7 +229,7 @@ class IPay
      * @return \stdClass
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function refund(string $order_id, int $amount, string $token = null): \stdClass
+    public function refund(string $order_id, int $amount, string $token = null): ?\stdClass
     {
         $url = config('ipay.url') . '/checkout/refund';
 


### PR DESCRIPTION
Refund request, if successful, returns 200 OK with empty body: https://developer.ipay.ge/v1/#tag/Refund
Return type for refund() should be nullable.